### PR TITLE
Fixed some typos in README and removed e.g. from example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Leader-board for the ZeroSpeech 2020 challenge can be found [here](https://zeros
     
 ## Training
    
-1.  Train the VQ-CPC model (pretrained weights are given above):
+1.  Train the VQ-CPC model (or download pretrained weights
+    [here](https://github.com/bshall/VectorQuantizedCPC/releases/tag/v0.1):
     ```
     python train_cpc.py checkpoint_dir=path/to/checkpoint_dir dataset=[2019/english or 2019/surprise]
     ```
@@ -87,7 +88,8 @@ Example usage:
 ```
 python convert.py cpc_checkpoint=checkpoints/cpc/english2019/model.ckpt-25000.pt vocoder_checkpoint=checkpoints/vocoder/english2019/model.ckpt-150000.pt in_dir=../datasets/2020/2019 out_dir=submission/2019/english/test synthesis_list=datasets/2019/english/synthesis.json in_dir=../../Datasets/2020/2019 dataset=2019/english
 ```
-Voice conversion samples will be available soon.
+Voice conversion samples are available
+[here](https://bshall.github.io/VectorQuantizedCPC/).
 
 ### ABX Score
     

--- a/README.md
+++ b/README.md
@@ -38,26 +38,29 @@ Leader-board for the ZeroSpeech 2020 challenge can be found [here](https://zeros
     Note: `in_dir` must be the path to the `2019` folder. 
     For `dataset` choose between `2019/english` or `2019/surprise`.
     Other datasets will be added in the future.
+    Example usage:
     ```
-    e.g. python preprecess.py in_dir=../datasets/2020/2019 dataset=2019/english
+    python preprocess.py in_dir=../datasets/2020/2019 dataset=2019/english
     ```
     
 ## Training
    
-1.  Train the VQ-CPC model (pretrained weights will be released soon):
+1.  Train the VQ-CPC model (pretrained weights are given above):
     ```
     python train_cpc.py checkpoint_dir=path/to/checkpoint_dir dataset=[2019/english or 2019/surprise]
     ```
+    Example usage:
     ```
-    e.g. python train_cpc.py checkpoint_dir=checkpoints/cpc/2019english dataset=2019/english
+    python train_cpc.py checkpoint_dir=checkpoints/cpc/2019english dataset=2019/english
     ```
     
 2.  Train the vocoder:
     ```
     python train_vocoder.py cpc_checkpoint=path/to/cpc/checkpoint checkpoint_dir=path/to/checkpoint_dir dataset=[2019/english or 2019/surprise]
     ```
+    Example usage:
     ```
-    e.g. python train_vocoder.py cpc_checkpoint=checkpoints/cpc/english2019/model.ckpt-24000.pt checkpoint_dir=checkpoints/vocoder/english2019
+    python train_vocoder.py cpc_checkpoint=checkpoints/cpc/english2019/model.ckpt-24000.pt checkpoint_dir=checkpoints/vocoder/english2019
     ```
 
 ## Evaluation
@@ -80,8 +83,9 @@ Note: the `synthesis list` is a `json` file:
 containing a list of items with a) the path (relative to `in_dir`) of the source `wav` files;
 b) the target speaker (see `datasets/2019/english/speakers.json` for a list of options);
 and c) the target file name.
+Example usage:
 ```
-e.g. python convert.py cpc_checkpoint=checkpoints/cpc/english2019/model.ckpt-25000.pt vocoder_checkpoint=checkpoints/vocoder/english2019/model.ckpt-150000.pt in_dir=../datasets/2020/2019 out_dir=submission/2019/english/test synthesis_list=datasets/2019/english/synthesis.json in_dir=../../Datasets/2020/2019 dataset=2019/english
+python convert.py cpc_checkpoint=checkpoints/cpc/english2019/model.ckpt-25000.pt vocoder_checkpoint=checkpoints/vocoder/english2019/model.ckpt-150000.pt in_dir=../datasets/2020/2019 out_dir=submission/2019/english/test synthesis_list=datasets/2019/english/synthesis.json in_dir=../../Datasets/2020/2019 dataset=2019/english
 ```
 Voice conversion samples will be available soon.
 


### PR DESCRIPTION
Changed the example code snippets so that they can be copy-and-pasted directly, and fixed some typos.